### PR TITLE
Fixes build failing with PureScript 0.11.6

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,20 +7,21 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^2.1.0",
-    "purescript-console": "^2.0.0",
-    "purescript-tailrec": "^2.0.1",
-    "purescript-arrays": "^3.2.0",
-    "purescript-refs": "^2.0.0",
-    "purescript-foldable-traversable": "^2.1.0",
-    "purescript-maybe": "^2.0.1",
-    "purescript-aff": "^2.0.2",
-    "purescript-halogen-vdom": "^1.0.3",
-    "purescript-dom-indexed": "^1.0.0",
-    "purescript-unsafe-reference": "^1.0.0"
+    "purescript-prelude": "^3.1.0",
+    "purescript-console": "^3.0.0",
+    "purescript-tailrec": "^3.3.0",
+    "purescript-arrays": "^4.1.2",
+    "purescript-refs": "^3.0.0",
+    "purescript-foldable-traversable": "^3.6.0",
+    "purescript-maybe": "^3.0.0",
+    "purescript-aff": "^3.1.0",
+    "purescript-halogen-vdom": "^2.0.0",
+    "purescript-dom-indexed": "^3.0.0",
+    "purescript-unsafe-reference": "^2.0.0",
+    "purescript-exists": "^3.0.0"
   },
   "devDependencies": {
-    "purescript-psci-support": "^2.0.0",
-    "purescript-dom-classy": "^1.3.0"
+    "purescript-psci-support": "^3.0.0",
+    "purescript-dom-classy": "^2.1.0"
   }
 }

--- a/src/Spork/App.purs
+++ b/src/Spork/App.purs
@@ -44,13 +44,12 @@ import Data.Functor.Coproduct (Coproduct(..), coproduct, left, right)
 import Data.Maybe (Maybe(..), maybe)
 import Data.Monoid (class Monoid, mempty)
 import Data.Newtype (unwrap)
-import Data.Nullable (toMaybe)
 import Data.Tuple (Tuple(..), curry)
 import DOM (DOM)
 import DOM.HTML (window) as DOM
 import DOM.HTML.Types (htmlDocumentToDocument, htmlDocumentToParentNode) as DOM
 import DOM.HTML.Window (document) as DOM
-import DOM.Node.ParentNode (querySelector) as DOM
+import DOM.Node.ParentNode (QuerySelector(..), querySelector) as DOM
 import DOM.Node.Node (appendChild) as DOM
 import DOM.Node.Types (Node, elementToNode) as DOM
 import Halogen.VDom as V
@@ -90,7 +89,7 @@ purely = { model: _, effects: mempty }
 type AppEffects eff =
   ( dom ∷ DOM
   , ref ∷ REF
-  , err ∷ EXCEPTION
+  , exception ∷ EXCEPTION
   | eff
   )
 
@@ -203,7 +202,7 @@ run app (Interpreter interpret) el = runEventQueue \push →
         , buildAttributes: P.buildProp push
         }
     vmach ← V.buildVDom spec (unwrap (app.render app.init.model))
-    DOM.appendChild (Machine.extract vmach) el
+    _ ← DOM.appendChild (Machine.extract vmach) el
     runInterpreter (unBatch app.init.effects) (unBatch (app.subs app.init.model))
     pure (Step (tick false vmach app.init.model))
 
@@ -216,8 +215,8 @@ runWithSelector
 runWithSelector app interpret sel = do
   win ← DOM.window
   doc ← DOM.document win
-  bod ← DOM.querySelector sel (DOM.htmlDocumentToParentNode doc)
-  case toMaybe bod of
+  bod ← DOM.querySelector (DOM.QuerySelector sel) (DOM.htmlDocumentToParentNode doc)
+  case bod of
     Nothing → throwException (error ("Element does not exist: " <> sel))
     Just el → run app interpret (DOM.elementToNode el)
 

--- a/src/Spork/Html/Core.purs
+++ b/src/Spork/Html/Core.purs
@@ -125,7 +125,7 @@ instance stepValueToPropValue :: ToPropValue StepValue where
 instance wrapValueToPropValue :: ToPropValue WrapValue where
   toPropValue = P.propFromString <<< renderWrapValue
 
-newtype IProp (r ∷ # *) i = IProp (P.Prop i)
+newtype IProp (r ∷ # Type) i = IProp (P.Prop i)
 
 text ∷ ∀ i. String → Html i
 text = Html <<< V.Text

--- a/src/Spork/Html/Events.purs
+++ b/src/Spork/Html/Events.purs
@@ -5,7 +5,7 @@ import Control.Monad.Except (runExcept)
 import Data.Either (Either(..))
 import Data.Foreign (Foreign, toForeign, F)
 import Data.Foreign (readBoolean, readInt, readString) as F
-import Data.Foreign.Index (prop) as F
+import Data.Foreign.Index (readProp) as F
 import Data.Maybe (Maybe(..))
 import DOM.Event.Types (Event, MouseEvent, KeyboardEvent, FocusEvent)
 import DOM.HTML.Event.Types (DragEvent)
@@ -130,8 +130,8 @@ type ForeignDecoder a = Foreign → F a
 
 currentTargetValue ∷ ForeignDecoder String
 currentTargetValue =
-  F.prop "currentTarget"
-  >=> F.prop "value"
+  F.readProp "currentTarget"
+  >=> F.readProp "value"
   >=> F.readString
 
 foreignHandler ∷ ∀ a r i. ForeignDecoder a → String → (a → Maybe i) → IProp r i
@@ -152,14 +152,14 @@ onSelectedIndexChange ∷ ∀ r i. (Int → Maybe i) → IProp (selectedIndex �
 onSelectedIndexChange = foreignHandler decoder "change"
   where
     decoder =
-      F.prop "currentTarget"
-      >=> F.prop "selectedIndex"
+      F.readProp "currentTarget"
+      >=> F.readProp "selectedIndex"
       >=> F.readInt
 
 onChecked ∷ ∀ r i. (Boolean → Maybe i) → IProp (checked ∷ Boolean, onChange ∷ Event | r) i
 onChecked = foreignHandler decoder "change"
   where
     decoder =
-      F.prop "currentTarget"
-      >=> F.prop "checked"
+      F.readProp "currentTarget"
+      >=> F.readProp "checked"
       >=> F.readBoolean

--- a/src/Spork/Html/Thunk.purs
+++ b/src/Spork/Html/Thunk.purs
@@ -17,7 +17,7 @@ import Halogen.VDom as V
 import Unsafe.Coerce (unsafeCoerce)
 import Unsafe.Reference (reallyUnsafeRefEq)
 
-foreign import data TArg ∷ *
+foreign import data TArg ∷ Type
 
 data Thunk' f j i = Thunk' (f i → f j) (TArg → TArg → Boolean) (TArg → f i) TArg
 


### PR DESCRIPTION
Hi! 

Thank you for purescript-spork. Build failed in PureScript 0.11.6. To fix it I've updated: 

- `bower.json`
- `Spork.Html.Thunk`
- `Spork.Html.Core`
- `Spork.Html.Events`
- `Spork.App`

Viktor

---

    Error 1 of 8:

    in module Spork.Html.Thunk
    at src/Spork/Html/Thunk.purs line 22, column 1 - line 22, column 1

      Unable to parse module:
      The `*` symbol is no longer used for the kind of types.
    The new equivalent is the named kind `Type`.

---

    Error 2 of 8:

    in module Spork.Html.Core
    at src/Spork/Html/Core.purs line 128, column 23 - line 128, column 23

      Unable to parse module:
      The `*` symbol is no longer used for the kind of types.
    The new equivalent is the named kind `Type`.

---

    Error 3 of 8:

    in module Spork.Html.Thunk
    at src/Spork/Html/Thunk.purs line 12, column 1 - line 12, column 49

      Module Data.Exists was not found.
      Make sure the source file exists, and that it has been provided as an input to psc.

---

    Error 4 of 8:

    in module Spork.Html.Events
    at src/Spork/Html/Events.purs line 8, column 28 - line 8, column 32

      Cannot import value prop from module Data.Foreign.Index
      It either does not exist or the module does not export it.

---

    Error 5 of 8:

    in module Spork.App
    at src/Spork/App.purs line 206, column 5 - line 206, column 47

      A result of type
            
        Node
            
      was implicitly discarded in a do notation block.
      You can use _ <- ... to explicitly discard the result.

---

    Error 6 of 8:

    in module Spork.App
    at src/Spork/App.purs line 219, column 27 - line 219, column 30

      Could not match type
              
        String
              
      with type
                     
        QuerySelector

---

    Error 7 of 8:

    in module Spork.App
    at src/Spork/App.purs line 220, column 16 - line 220, column 19

      Could not match type
             
        Maybe
             
      with type
                
        Nullable

---

    Error 8 of 8:

    in module Spork.App
    at src/Spork/App.purs line 222, column 15 - line 222, column 55

      Could not match type
                          
        ( err :: EXCEPTION
        , ref :: REF      
        , dom :: DOM      
        | eff2            
        )                 
                          
      with type
                                
        ( exception :: EXCEPTION
        , dom :: DOM            
        | t3                    
        ) 