### PR TITLE
Reworked internals

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,8 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-dom-classy": "^2.1.0"
+    "purescript-dom-classy": "^2.1.0",
+    "purescript-simple-json": "^1.0.0",
+    "purescript-routing": "^6.1.1"
   }
 }

--- a/src/Spork/App.purs
+++ b/src/Spork/App.purs
@@ -10,54 +10,40 @@ module Spork.App
   , exec
   , subscribe
   , purely
-  , Push
-  , InterpreterSpec
-  , Interpreter(..)
-  , Step(..)
-  , Loop(..)
-  , EventQueue
-  , runEventQueue
   , run
   , runWithSelector
-  , makeInterpreter
-  , basicInterpreter
-  , pureInterpreter
-  , toBasicEff
-  , toBasicAff
-  , basicEff
-  , basicAff
+  , module Exports
   ) where
 
 import Prelude
-import Control.Monad.Aff (Aff, runAff)
+
 import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Exception (EXCEPTION, Error, throwException, error)
-import Control.Monad.Eff.Ref (REF, newRef, writeRef, readRef)
-import Control.Monad.Rec.Class as MR
-import Data.Array as Array
-import Data.Const (Const)
-import Data.Either (Either(..), either)
-import Data.Foldable (for_, traverse_)
-import Data.Function.Uncurried (runFn2)
-import Data.Functor.Compose (Compose(..))
-import Data.Functor.Coproduct (Coproduct(..), coproduct, left, right)
-import Data.Maybe (Maybe(..), maybe)
-import Data.Monoid (class Monoid, mempty)
-import Data.Newtype (unwrap)
-import Data.Tuple (Tuple(..), curry)
+import Control.Monad.Eff.Exception (EXCEPTION, throwException, error)
+import Control.Monad.Eff.Ref (REF)
 import DOM (DOM)
 import DOM.HTML (window) as DOM
 import DOM.HTML.Types (htmlDocumentToDocument, htmlDocumentToParentNode) as DOM
 import DOM.HTML.Window (document) as DOM
-import DOM.Node.ParentNode (QuerySelector(..), querySelector) as DOM
 import DOM.Node.Node (appendChild) as DOM
+import DOM.Node.ParentNode (QuerySelector(..), querySelector) as DOM
 import DOM.Node.Types (Node, elementToNode) as DOM
+import Data.Const (Const)
+import Data.Either (Either(..))
+import Data.Foldable (traverse_)
+import Data.Functor.Compose (Compose(..))
+import Data.Functor.Coproduct (Coproduct, left, right)
+import Data.Maybe (Maybe(..))
+import Data.Monoid (class Monoid, mempty)
+import Data.Newtype (unwrap)
 import Halogen.VDom as V
 import Halogen.VDom.DOM.Prop as P
 import Halogen.VDom.Machine as Machine
-import Halogen.VDom.Util (refEq)
+import Spork.EventQueue (EventQueue, Loop(..), looped, makeEventQueue, runEventQueue)
+import Spork.EventQueue (Push) as Exports
 import Spork.Html (Html)
 import Spork.Html.Thunk (buildThunk)
+import Spork.Interpreter (Interpreter(..))
+import Unsafe.Reference (unsafeRefEq)
 
 newtype Batch f a = Batch (Compose Array f a)
 
@@ -109,166 +95,97 @@ type PureApp s i = App (Const Void) (Const Void) s i
 
 type BasicApp m s i = App m (Const Void) s i
 
-type Push eff i = i → Eff eff Unit
-
-newtype Interpreter eff m q i = Interpreter (Push eff i → Coproduct m q i → Eff eff Unit)
-
-newtype Step m i = Step (i → m (Loop m i))
-
-data Loop m i = Loop (i → m (Loop m i)) (m (Step m i))
-
-type EventQueue m i = (i → m Unit) → m (Step m i)
-
-runEventQueue
-  ∷ ∀ eff i
-  . EventQueue (Eff (ref ∷ REF | eff)) i
-  → Eff (ref ∷ REF | eff) (i → Eff (ref ∷ REF | eff) Unit)
-runEventQueue proc = do
-  queue   ← newRef Nothing
-  machine ← newRef Nothing
-
+makeApp
+  ∷ ∀ eff m q s i
+  . Functor m
+  ⇒ Functor q
+  ⇒ (Interpreter (AppEffects eff) m q)
+  → App m q s i
+  → DOM.Node
+  → EventQueue (Eff (AppEffects eff)) (Either (Coproduct m q (Eff (AppEffects eff) Unit)) i)
+makeApp (Interpreter interpreter) app el = makeEventQueue \push →
   let
-    push i = do
-      q ← readRef queue
-      case q of
-        Nothing → do
-          writeRef queue (Just [i])
-          start
-        Just is →
-          writeRef queue (Just (Array.snoc is i))
+    pushInput = push <<< Right
+    pushEffect = push <<< Left <<< left
+    pushSub = push <<< Left <<< right
 
-    start = do
-      step ← readRef machine
-      for_ step (loop <<< startLoop)
+    queueInterp effs subs = do
+      traverse_ (pushEffect <<< map pushInput) $ unBatch effs
+      traverse_ (pushSub <<< map pushInput) $ unBatch subs
 
-    startLoop (Step fn) =
-      Loop fn (pure (Step fn))
+    init = do
+      document ←
+        DOM.window
+          >>= DOM.document
+          >>> map DOM.htmlDocumentToDocument
+      let
+        vdomSpec = V.VDomSpec
+          { document
+          , buildWidget: buildThunk unwrap
+          , buildAttributes: P.buildProp pushInput
+          }
+      vdom ← V.buildVDom vdomSpec (unwrap (app.render app.init.model))
+      void $ DOM.appendChild (Machine.extract vdom) el
+      interpret ← looped <$> interpreter (push <<< Left)
+      queueInterp app.init.effects (app.subs app.init.model)
+      pure
+        { model: app.init.model
+        , needsRender: false
+        , interpret
+        , vdom
+        }
 
-    loop = MR.tailRecM \(Loop next done) → do
-      q ← readRef queue
-      case q >>= Array.uncons of
-        Just { head, tail } → do
-          writeRef queue (Just tail)
-          MR.Loop <$> next head
-        Nothing → do
-          step ← done
-          q' ← readRef queue
-          readRef queue >>= maybe true Array.null >>> if _
-            then do
-              writeRef machine (Just step)
-              writeRef queue Nothing
-              pure (MR.Done unit)
-            else
-              pure (MR.Loop (startLoop step))
+    tick state@{ interpret: Loop k _ } = case _ of
+      Left i → do
+        nextInterpret ← k i
+        pure $ state { interpret = nextInterpret }
+      Right i → do
+        let
+          next = app.update state.model i
+          needsRender = state.needsRender || not (unsafeRefEq state.model next.model)
+          nextState = state { model = next.model, needsRender = needsRender }
+        queueInterp next.effects (app.subs next.model)
+        pure nextState
 
-  step ← proc push
-  writeRef machine (Just step)
-  start $> push
+    flush state = do
+      nextVDom ←
+        if state.needsRender
+          then Machine.step state.vdom (unwrap (app.render state.model))
+          else pure state.vdom
+      nextInterpret ←
+        case state.interpret of
+          Loop _ f → looped <$> f
+      pure
+        { model: state.model
+        , vdom: nextVDom
+        , interpret: nextInterpret
+        , needsRender: false
+        }
+  in
+    { init, tick, flush }
 
 run
   ∷ ∀ eff m q s i
-  . App m q s i
-  → (Interpreter (AppEffects eff) m q i)
+  . Functor m
+  ⇒ Functor q
+  ⇒ (Interpreter (AppEffects eff) m q)
+  → App m q s i
   → DOM.Node
   → Eff (AppEffects eff) (i → Eff (AppEffects eff) Unit)
-run app (Interpreter interpret) el = runEventQueue \push →
-  let
-    tick doRender vmach model input = do
-      let
-        res = app.update model input
-        doRender' = doRender || not (runFn2 refEq model res.model)
-        render' = if doRender'
-          then render vmach res.model
-          else pure (Step (tick false vmach res.model))
-      runInterpreter (unBatch res.effects) (unBatch (app.subs res.model))
-      pure (Loop (tick doRender' vmach res.model) render')
-
-    render vmach model = do
-      vmach' ← Machine.step vmach (unwrap (app.render model))
-      pure (Step (tick false vmach' model))
-
-    runInterpreter effs subs =
-      traverse_ (interpret push) (map left effs <> map right subs)
-
-  in do
-    document ←
-      DOM.window
-        >>= DOM.document
-        >>> map DOM.htmlDocumentToDocument
-    let
-      spec = V.VDomSpec
-        { document
-        , buildWidget: buildThunk unwrap
-        , buildAttributes: P.buildProp push
-        }
-    vmach ← V.buildVDom spec (unwrap (app.render app.init.model))
-    _ ← DOM.appendChild (Machine.extract vmach) el
-    runInterpreter (unBatch app.init.effects) (unBatch (app.subs app.init.model))
-    pure (Step (tick false vmach app.init.model))
+run interpreter app = map (_ <<< Right) <<< runEventQueue <<< makeApp interpreter app
 
 runWithSelector
   ∷ ∀ eff m q s i
-  . App m q s i
-  → (Interpreter (AppEffects eff) m q i)
+  . Functor m
+  ⇒ Functor q
+  ⇒ (Interpreter (AppEffects eff) m q)
+  → App m q s i
   → String
   → Eff (AppEffects eff) (i → Eff (AppEffects eff) Unit)
-runWithSelector app interpret sel = do
+runWithSelector interpret app sel = do
   win ← DOM.window
   doc ← DOM.document win
   bod ← DOM.querySelector (DOM.QuerySelector sel) (DOM.htmlDocumentToParentNode doc)
   case bod of
     Nothing → throwException (error ("Element does not exist: " <> sel))
-    Just el → run app interpret (DOM.elementToNode el)
-
-type InterpreterSpec eff m q s i =
-  { spawnEffect ∷ Push eff i → m i → s → Eff eff s
-  , spawnSub ∷ Push eff i → q i → s → Eff eff s
-  , flush ∷ s → Eff eff s
-  , init ∷ Eff eff s
-  }
-
-makeInterpreter
-  ∷ ∀ eff m q s i
-  . InterpreterSpec (ref ∷ REF | eff) m q s i
-  → Eff (ref ∷ REF | eff) (Interpreter (ref ∷ REF | eff) m q i)
-makeInterpreter spec = Interpreter <<< curry <$> runEventQueue \_ →
-  let
-    tick state (Tuple push (Coproduct input)) = do
-      state' ← case input of
-        Left eff  → spec.spawnEffect push eff state
-        Right sub → spec.spawnSub push sub state
-      pure (Loop (tick state') (flush state'))
-
-    flush state = do
-      state' ← spec.flush state
-      pure (Step (tick state'))
-
-  in do
-    initialState ← spec.init
-    pure (Step (tick initialState))
-
-basicInterpreter
-  ∷ ∀ eff m i
-  . (Push eff i → m i → Eff eff Unit)
-  → InterpreterSpec eff m (Const Void) Unit i
-basicInterpreter spawn =
-  { spawnEffect: \push eff _ → spawn push eff
-  , spawnSub: \_ v _ → absurd (unwrap v)
-  , flush: pure
-  , init: pure unit
-  }
-
-pureInterpreter ∷ ∀ eff i. Interpreter eff (Const Void) (Const Void) i
-pureInterpreter = Interpreter \_ → coproduct (absurd <<< unwrap) (absurd <<< unwrap)
-
-basicEff ∷ ∀ eff i. InterpreterSpec eff (Eff eff) (Const Void) Unit i
-basicEff = toBasicEff id
-
-toBasicEff ∷ ∀ eff f i. (f ~> Eff eff) → InterpreterSpec eff f (Const Void) Unit i
-toBasicEff nat = basicInterpreter \push a → push =<< nat a
-
-basicAff ∷ ∀ eff i. (Error → Eff eff Unit) → InterpreterSpec eff (Aff eff) (Const Void) Unit i
-basicAff = toBasicAff id
-
-toBasicAff ∷ ∀ eff f i. (f ~> Aff eff) → (Error → Eff eff Unit) → InterpreterSpec eff f (Const Void) Unit i
-toBasicAff nat = basicInterpreter <<< \a b c → void (runAff (either a b) (nat c))
+    Just el → run interpret app  (DOM.elementToNode el)

--- a/src/Spork/EventQueue.purs
+++ b/src/Spork/EventQueue.purs
@@ -1,0 +1,114 @@
+module Spork.EventQueue
+  ( Tick
+  , Step(..)
+  , Loop(..)
+  , EventQueue
+  , EventQueueSpec
+  , QueueEffects
+  , Push
+  , makeEventQueue
+  , runEventQueue
+  , looped
+  ) where
+
+import Prelude
+
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Ref (REF, newRef, writeRef, readRef)
+import Control.Monad.Rec.Class as MR
+import Data.Array as Array
+import Data.Foldable (for_)
+import Data.Maybe (Maybe(..), maybe)
+import Data.Newtype (class Newtype, unwrap)
+
+type Tick f m i = m (f m i)
+
+newtype Step m i = Step (i → Tick Loop m i)
+
+data Loop m i = Loop (i → Tick Loop m i) (Tick Step m i)
+
+type Push m i = i → m Unit
+
+type EventQueue m i = Push m i → Tick Step m i
+
+type QueueEffects eff = (ref ∷ REF | eff)
+
+derive instance newtypeStep ∷ Newtype (Step m i) _
+
+looped ∷ ∀ m i. Applicative m ⇒ Step m i → Loop m i
+looped step = Loop (unwrap step) (pure step)
+
+type EventQueueSpec m s i =
+  { init ∷ m s
+  , tick ∷ s → i → m s
+  , flush ∷ s → m s
+  }
+
+makeEventQueue
+  ∷ ∀ eff s i
+  . (Push (Eff eff) i → EventQueueSpec (Eff eff) s i)
+  → EventQueue (Eff eff) i
+makeEventQueue specFn push =
+  let
+    spec ∷ EventQueueSpec (Eff eff) s i
+    spec = specFn push
+
+    tick ∷ s → i → Tick Loop (Eff eff) i
+    tick state input = do
+      nextState ← spec.tick state input
+      pure $ Loop (tick nextState) (flush nextState)
+
+    flush ∷ s → Tick Step (Eff eff) i
+    flush state = Step <<< tick <$> spec.flush state
+  in
+    Step <<< tick <$> spec.init
+
+runEventQueue
+  ∷ ∀ eff i
+  . EventQueue (Eff (QueueEffects eff)) i
+  → Eff (QueueEffects eff) (Push (Eff (QueueEffects eff)) i)
+runEventQueue proc = do
+  queue   ← newRef Nothing
+  machine ← newRef Nothing
+
+  let
+    push ∷ Push (Eff (QueueEffects eff)) i
+    push i = do
+      q ← readRef queue
+      case q of
+        Nothing → do
+          writeRef queue (Just [i])
+          start
+        Just is →
+          writeRef queue (Just (Array.snoc is i))
+
+    start ∷ Eff (QueueEffects eff) Unit
+    start = do
+      step ← readRef machine
+      for_ step (loop <<< startLoop)
+
+    startLoop ∷ Step (Eff (QueueEffects eff)) i → Loop (Eff (QueueEffects eff)) i
+    startLoop (Step fn) = Loop fn (pure (Step fn))
+
+    loop ∷ Loop (Eff (QueueEffects eff)) i → Eff (QueueEffects eff) Unit
+    loop = MR.tailRecM \(Loop next done) → do
+      q ← readRef queue
+      case q >>= Array.uncons of
+        Just { head, tail } → do
+          writeRef queue (Just tail)
+          MR.Loop <$> next head
+        Nothing → do
+          step ← done
+          isEmpty ← maybe true Array.null <$> readRef queue
+          if isEmpty
+            then do
+              writeRef machine (Just step)
+              writeRef queue Nothing
+              pure (MR.Done unit)
+            else
+              pure (MR.Loop (startLoop step))
+
+  step ← proc push
+  writeRef machine (Just step)
+  start
+  pure push

--- a/src/Spork/Interpreter.purs
+++ b/src/Spork/Interpreter.purs
@@ -1,0 +1,46 @@
+module Spork.Interpreter
+  ( Interpreter(..)
+  , pureInterpreter
+  , basicEff
+  , toBasicEff
+  , basicAff
+  , toBasicAff
+  ) where
+
+import Prelude
+
+import Control.Monad.Aff (Aff, runAff)
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Exception (Error)
+import Data.Const (Const)
+import Data.Either (either)
+import Data.Functor.Coproduct (Coproduct, coproduct)
+import Data.Newtype (unwrap)
+import Spork.EventQueue (EventQueue, makeEventQueue)
+
+newtype Interpreter eff m q = Interpreter (EventQueue (Eff eff) (Coproduct m q (Eff eff Unit)))
+
+basicInterpreter
+  ∷ ∀ eff m
+  . (m (Eff eff Unit) → Eff eff Unit)
+  → Interpreter eff m (Const Void)
+basicInterpreter onEffect = Interpreter $ makeEventQueue $ const
+  { init: pure unit
+  , tick: const $ coproduct onEffect (absurd <<< unwrap)
+  , flush: pure
+  }
+
+pureInterpreter ∷ ∀ eff. Interpreter eff (Const Void) (Const Void)
+pureInterpreter = basicInterpreter (absurd <<< unwrap)
+
+basicEff ∷ ∀ eff. Interpreter eff (Eff eff) (Const Void)
+basicEff = toBasicEff id
+
+toBasicEff ∷ ∀ eff f. (f ~> Eff eff) → Interpreter eff f (Const Void)
+toBasicEff nat = basicInterpreter (join <<< nat)
+
+basicAff ∷ ∀ eff. (Error → Eff eff Unit) → Interpreter eff (Aff eff) (Const Void)
+basicAff = toBasicAff id
+
+toBasicAff ∷ ∀ eff f. (f ~> Aff eff) → (Error → Eff eff Unit) → Interpreter eff f (Const Void)
+toBasicAff nat onError = basicInterpreter (void <<< runAff (either onError id) <<< nat)

--- a/src/Spork/Interpreter.purs
+++ b/src/Spork/Interpreter.purs
@@ -16,7 +16,7 @@ import Data.Const (Const)
 import Data.Either (either)
 import Data.Functor.Coproduct (Coproduct, coproduct)
 import Data.Newtype (unwrap)
-import Spork.EventQueue (EventQueue, makeEventQueue)
+import Spork.EventQueue (EventQueue, fromEventQueueSpec)
 
 newtype Interpreter eff m q = Interpreter (EventQueue (Eff eff) (Coproduct m q (Eff eff Unit)))
 
@@ -24,7 +24,7 @@ basicInterpreter
   ∷ ∀ eff m
   . (m (Eff eff Unit) → Eff eff Unit)
   → Interpreter eff m (Const Void)
-basicInterpreter onEffect = Interpreter $ makeEventQueue $ const
+basicInterpreter onEffect = Interpreter $ fromEventQueueSpec $ const
   { init: pure unit
   , tick: const $ coproduct onEffect (absurd <<< unwrap)
   , flush: pure

--- a/test/src/Main.purs
+++ b/test/src/Main.purs
@@ -433,11 +433,13 @@ main = do
       >>= DOM.getItem storageKey
       >>> map (_ >>= readJSON >>> hush)
 
-  driver ←
-    App.runWithSelector
+  inst ←
+    App.makeWithSelector
       (toBasicEff runEffect)
       (app storedModel)
       "#app"
 
   hashes \oldHash newHash →
-    F.for_ (routeAction newHash) driver
+    F.for_ (routeAction newHash) inst.push
+
+  inst.run


### PR DESCRIPTION
* Moved EventQueue/Interpreter to separate modules
* Reformulated how the interpreter pattern works
* The interpreter state now steps with the main event queue
* Updated demo to support local storage and routing