### PR TITLE
More general combinators for interpreters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: node_js
+dist: trusty
+sudo: required
+node_js: stable
+install:
+  - npm install
+  - npm install -g bower
+  - bower install --production
+script:
+  - npm run -s build
+  - bower install
+  - npm run -s test
+after_success:
+- >-
+  test $TRAVIS_TAG &&
+  echo $GITHUB_TOKEN | pulp login &&
+  echo y | pulp publish --no-push ||
+  git status

--- a/package.json
+++ b/package.json
@@ -1,7 +1,12 @@
 {
   "private": true,
   "scripts": {
-    "build": "pulp build",
+    "build": "pulp build -- --strict --censor-lib",
     "test": "pulp build -I test/src --to test/app.js -m Test.Main"
+  },
+  "devDependencies": {
+    "pulp": "^12.0.0",
+    "purescript": "^0.11.6",
+    "purescript-psa": "^0.5.0"
   }
 }

--- a/src/Spork/Interpreter.purs
+++ b/src/Spork/Interpreter.purs
@@ -1,10 +1,12 @@
 module Spork.Interpreter
   ( Interpreter(..)
-  , pureInterpreter
+  , merge
+  , never
+  , liftNat
+  , liftCont
   , basicEff
-  , toBasicEff
   , basicAff
-  , toBasicAff
+  , throughAff
   ) where
 
 import Prelude
@@ -13,34 +15,63 @@ import Control.Monad.Aff (Aff, runAff)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Exception (Error)
 import Data.Const (Const)
-import Data.Either (either)
-import Data.Functor.Coproduct (Coproduct, coproduct)
+import Data.Either (Either(..), either)
+import Data.Functor.Coproduct (Coproduct(..), left, right)
 import Data.Newtype (unwrap)
-import Spork.EventQueue (EventQueue, fromEventQueueSpec)
+import Spork.EventQueue (EventQueue, Loop(..), Step(..), Tick, looped)
 
-newtype Interpreter eff m q = Interpreter (EventQueue (Eff eff) (Coproduct m q (Eff eff Unit)))
+newtype Interpreter f m = Interpreter (EventQueue m (f (m Unit)))
 
-basicInterpreter
-  ∷ ∀ eff m
-  . (m (Eff eff Unit) → Eff eff Unit)
-  → Interpreter eff m (Const Void)
-basicInterpreter onEffect = Interpreter $ fromEventQueueSpec $ const
-  { init: pure unit
-  , tick: const $ coproduct onEffect (absurd <<< unwrap)
-  , flush: pure
-  }
+merge
+  ∷ ∀ f g m
+  . Applicative m
+  ⇒ Interpreter f m
+  → Interpreter g m
+  → Interpreter (Coproduct f g) m
+merge (Interpreter lhs) (Interpreter rhs) = Interpreter \push →
+  let
+    update
+      ∷ Loop m (f (m Unit))
+      → Loop m (g (m Unit))
+      → Coproduct f g (m Unit)
+      → Tick Loop m (Coproduct f g (m Unit))
+    update l@(Loop loopL _) r@(Loop loopR _) (Coproduct i) = case i of
+      Left iL → loopL iL <#> \nextL → Loop (update nextL r) (commit nextL r)
+      Right iR → loopR iR <#> \nextR → Loop (update l nextR) (commit l nextR)
 
-pureInterpreter ∷ ∀ eff. Interpreter eff (Const Void) (Const Void)
-pureInterpreter = basicInterpreter (absurd <<< unwrap)
+    commit
+      ∷ Loop m (f (m Unit))
+      → Loop m (g (m Unit))
+      → Tick Step m (Coproduct f g (m Unit))
+    commit (Loop _ commitL) (Loop _ commitR) =
+      map Step $ update
+        <$> map looped commitL
+        <*> map looped commitR
+  in
+    map Step $ update
+      <$> (map looped $ lhs $ push <<< left)
+      <*> (map looped $ rhs $ push <<< right)
 
-basicEff ∷ ∀ eff. Interpreter eff (Eff eff) (Const Void)
-basicEff = toBasicEff id
+never ∷ ∀ m. Applicative m ⇒ Interpreter (Const Void) m
+never = Interpreter (const (pure (Step (absurd <<< unwrap))))
 
-toBasicEff ∷ ∀ eff f. (f ~> Eff eff) → Interpreter eff f (Const Void)
-toBasicEff nat = basicInterpreter (join <<< nat)
+liftCont ∷ ∀ f m. Applicative m ⇒ (f (m Unit) → m Unit) → Interpreter f m
+liftCont k = Interpreter (const (pure (Step loop)))
+  where
+  loop ∷ f (m Unit) → Tick Loop m (f (m Unit))
+  loop a = k a $> Loop loop (pure (Step loop))
 
-basicAff ∷ ∀ eff. (Error → Eff eff Unit) → Interpreter eff (Aff eff) (Const Void)
-basicAff = toBasicAff id
+liftNat ∷  ∀ f m. Monad m ⇒ (f ~> m) → Interpreter f m
+liftNat k = Interpreter (const (pure (Step loop)))
+  where
+  loop ∷ f (m Unit) → Tick Loop m (f (m Unit))
+  loop a = join (k a) $> Loop loop (pure (Step loop))
 
-toBasicAff ∷ ∀ eff f. (f ~> Aff eff) → (Error → Eff eff Unit) → Interpreter eff f (Const Void)
-toBasicAff nat onError = basicInterpreter (void <<< runAff (either onError id) <<< nat)
+basicEff ∷ ∀ eff. Interpreter (Eff eff) (Eff eff)
+basicEff = liftNat id
+
+basicAff ∷ ∀ eff. (Error → Eff eff Unit) → Interpreter (Aff eff) (Eff eff)
+basicAff = throughAff id
+
+throughAff ∷ ∀ f eff. (f ~> Aff eff) → (Error → Eff eff Unit) → Interpreter f (Eff eff)
+throughAff nat k = liftCont (void <<< runAff (either k id) <<< nat)

--- a/test/src/Main.purs
+++ b/test/src/Main.purs
@@ -25,7 +25,7 @@ import Simple.JSON (readJSON, writeJSON)
 import Spork.App as App
 import Spork.Html as H
 import Spork.Html.Elements.Keyed as K
-import Spork.Interpreter (toBasicEff)
+import Spork.Interpreter (liftNat, merge, never)
 
 type Model =
   { todos ∷ Array Todo
@@ -435,7 +435,7 @@ main = do
 
   inst ←
     App.makeWithSelector
-      (toBasicEff runEffect)
+      (liftNat runEffect `merge` never)
       (app storedModel)
       "#app"
 


### PR DESCRIPTION
I changed the way `Interpreter` works which allows for a more general formulation. The problem with the old combinators was that you couldn't stack your own subscriptions on top of the existing Eff/Aff interpreters, since they were hard coded to _no_ subscriptions. I've added a more general `merge` combinator that can run two interpreters as a `Coproduct`, which is what `makeApp` expects. This means you can do something like:

```purescript
-- No subscriptions
basicEff `merge` never

-- Custom subscriptions
basicEff `merge` mySubInterpreter
```